### PR TITLE
fix: update props types in detail page

### DIFF
--- a/frontend/src/app/[lang]/(features)/account/[address]/page.tsx
+++ b/frontend/src/app/[lang]/(features)/account/[address]/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next'
 import type { Address } from 'viem'
 import MyPage from './_components/MyPage'
 
-const Page = async (props: { params: Promise<{ address: string }> }) => {
-  const { address } = await props.params
+const Page = async ({ params }: { params: { address: string } }) => {
+  const { address } = params
   return <MyPage address={address as Address} />
 }
 

--- a/frontend/src/app/[lang]/(features)/detail/[id]/page.tsx
+++ b/frontend/src/app/[lang]/(features)/detail/[id]/page.tsx
@@ -2,8 +2,8 @@ import { notFound } from 'next/navigation'
 import { getAsset } from '@/server/asset/query'
 import Detail from '../_components/Detail'
 
-const DetailPage = async (props: { params: Promise<{ id: string }> }) => {
-  const { id } = await (await props).params
+const DetailPage = async ({ params }: { params: { id: string } }) => {
+  const { id } = params
   if (Number(id) > 2022) {
     // CryptoMaids max token id is 2022
     return notFound()
@@ -14,8 +14,8 @@ const DetailPage = async (props: { params: Promise<{ id: string }> }) => {
 
 export default DetailPage
 
-export const generateMetadata = async (props: { params: Promise<{ id: number }> }) => {
-  const { id } = await (await props).params
+export const generateMetadata = async ({ params }: { params: { id: number } }) => {
+  const { id } = params
 
   if (id > 2022) {
     // CryptoMaids max token id is 2022

--- a/frontend/src/app/[lang]/(features)/top/page.tsx
+++ b/frontend/src/app/[lang]/(features)/top/page.tsx
@@ -1,7 +1,7 @@
 import Top from '@/app/[lang]/(features)/top/_components/Top'
 
-const Page = async (params: { params: Promise<{ lang: string }> }) => {
-  const { lang } = await params.params
+const Page = async ({ params }: { params: { lang: string } }) => {
+  const { lang } = params
 
   return <Top lang={lang} />
 }


### PR DESCRIPTION
This PR updates the props types in the detail page to use the new format, replacing the old `Promise`-based type with a direct destructuring approach. This ensures consistency and modernizes the codebase.