### PR TITLE
fix: correct typo 'antialiase' to 'antialiased' in layout.tsx

### DIFF
--- a/frontend/src/app/[lang]/layout.tsx
+++ b/frontend/src/app/[lang]/layout.tsx
@@ -43,7 +43,7 @@ const RootLayout = async ({ children, params }: { children: React.ReactNode; par
 
   return (
     <html lang={lang} dir={dir(lang)}>
-      <body className={cn('min-h-screen w-screen bg-neutral-950 antialiase', dotGothic.className)}>
+      <body className={cn('min-h-screen w-screen bg-neutral-950 antialiased', dotGothic.className)}>
         <Providers lang={lang}>
           <TopBar />
           <main className='bg-neutral-950 pb-4'>{children}</main>


### PR DESCRIPTION
## Summary
- Fixed CSS class name typo in layout.tsx: `antialiase` → `antialiased`

## Changes
- Corrected the typo in the body className that was causing incorrect antialiasing behavior

## Test plan
- [x] Verify the typo is corrected
- [x] Ensure no other instances of the typo exist
- [x] Confirm the page renders correctly with proper antialiasing

🤖 Generated with [Claude Code](https://claude.ai/code)